### PR TITLE
feat: 회원가입 및 로그인 api 구현

### DIFF
--- a/app/_hooks/useAuth.ts
+++ b/app/_hooks/useAuth.ts
@@ -1,0 +1,38 @@
+import { useAuthStore } from '@/_store/auth-store';
+import { signUp, signIn } from '@/api/auth';
+
+import { useMutation } from '@tanstack/react-query';
+
+export const useAuthMutation = () => {
+  const setAuthData = useAuthStore((state) => state.setAuthData);
+
+  const signUpMutation = useMutation({
+    mutationFn: signUp,
+    onSuccess: (response) => {
+      setAuthData({
+        accessToken: response.accessToken,
+        refreshToken: response.refreshToken,
+        user: response.user,
+      });
+    },
+    onError: (error) => {
+      console.error('회원가입 실패:', error);
+    },
+  });
+
+  const signInMutation = useMutation({
+    mutationFn: signIn,
+    onSuccess: (response) => {
+      setAuthData({
+        accessToken: response.accessToken,
+        refreshToken: response.refreshToken,
+        user: response.user,
+      });
+    },
+    onError: (error) => {
+      console.error('로그인 실패:', error);
+    },
+  });
+
+  return { signUpMutation, signInMutation };
+};

--- a/app/_store/auth-store.ts
+++ b/app/_store/auth-store.ts
@@ -1,0 +1,55 @@
+import { create } from 'zustand';
+
+interface User {
+  id: number;
+  email: string;
+  nickname: string;
+  image: string | null;
+}
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  user: User | null;
+  isLoggedIn: boolean;
+}
+
+interface AuthAction {
+  setAuthData: (data: {
+    accessToken: string;
+    refreshToken: string;
+    user: User;
+  }) => void;
+  clearAuthData: () => void;
+}
+
+export const useAuthStore = create<AuthState & AuthAction>((set) => ({
+  accessToken: localStorage.getItem('accessToken') || null,
+  refreshToken: localStorage.getItem('refreshToken') || null,
+  user: null,
+  isLoggedIn: !!localStorage.getItem('accessToken'),
+
+  setAuthData: (data) =>
+    set(() => {
+      localStorage.setItem('accessToken', data.accessToken);
+      localStorage.setItem('refreshToken', data.refreshToken);
+      return {
+        accessToken: data.accessToken,
+        refreshToken: data.refreshToken,
+        user: data.user,
+        isLoggedIn: true,
+      };
+    }),
+
+  clearAuthData: () =>
+    set(() => {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      return {
+        accessToken: null,
+        refreshToken: null,
+        user: null,
+        isLoggedIn: false,
+      };
+    }),
+}));

--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -1,0 +1,16 @@
+import { instance } from './axios-instance';
+
+export async function signUp(data: {
+  email: string;
+  nickname: string;
+  password: string;
+  passwordConfirmation: string;
+}) {
+  const response = await instance.post(`/auth/signUp`, data);
+  return response.data;
+}
+
+export async function signIn(data: { email: string; password: string }) {
+  const response = await instance.post(`/auth/signIn`, data);
+  return response.data;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@types/lodash.debounce": "^4.0.9",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -958,6 +959,23 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.17.13",


### PR DESCRIPTION
## 📄 작업 내용 요약
1. 회원가입 및 로그인 API 구현
- 회원가입: 사용자 이메일, 닉네임, 비밀번호, 비밀번호 확인을 받아 `auth/signUp` API로 요청 보냄
- 로그인: 사용자 이메일, 비밀번호를 받아 `auth/signIn` API로 요청 보냄
- 성공 시 `accessToken`과 `refreshToken`을 응답으로 받아서 상태에 저장함

2. 로그인 전역 상태 관리
- `zustand`를 사용해서 로그인 상태(`accessToken`, `refreshToken`를 전역적으로 관리
- 로그인 상태를 `useAuthStore`에서 관리, 로그인/회원가입 후에는 `setAuthData`를 통해 상태 업데이트
- 로그아웃 시 `clearAuthData`를 호출해 상태 초기화
- 로그인 상태는 `localStorage`에 저장됨

### 사용방법
회원가입: useAuthMutation 훅의 signUpMutation 사용
로그인: useAuthMutation 훅의 signInMutation 사용
로그인 상태 확인: useAuthStore에서 isLoggedIn과 user 사용
로그아웃: useAuthStore에서 clearAuthData 사용
토큰 갱신: 인터셉터에서 자동 처리

따로 테스트 페이지 만들고 회원가입, 로그인 간단하게 구현했는데 api 잘 받아왔습니다 : )
## 📎 Issue 번호
#24 
<!-- closed #번호 -->
