### PR TITLE
feat: Group API 구현, 낙관적 업데이트 훅 작성

### DIFF
--- a/app/_hooks/useAuth.ts
+++ b/app/_hooks/useAuth.ts
@@ -6,7 +6,7 @@ import { useMutation } from '@tanstack/react-query';
 export const useAuthMutation = () => {
   const setAuthData = useAuthStore((state) => state.setAuthData);
 
-  const signUpMutation = useMutation({
+  const useSignUp = useMutation({
     mutationFn: signUp,
     onSuccess: (response) => {
       setAuthData({
@@ -20,7 +20,7 @@ export const useAuthMutation = () => {
     },
   });
 
-  const signInMutation = useMutation({
+  const useSignIn = useMutation({
     mutationFn: signIn,
     onSuccess: (response) => {
       setAuthData({
@@ -34,5 +34,5 @@ export const useAuthMutation = () => {
     },
   });
 
-  return { signUpMutation, signInMutation };
+  return { useSignUp, useSignIn };
 };

--- a/app/_hooks/useGroup.ts
+++ b/app/_hooks/useGroup.ts
@@ -1,0 +1,118 @@
+import {
+  acceptGroupInvitation,
+  addGroupMember,
+  createGroup,
+  createGroupInvitation,
+  deleteGroupInfo,
+  deleteGroupMember,
+  getGroupInfo,
+  getGroupMember,
+  getGroupTasks,
+  updateGroupInfo,
+} from '@/_lib/api/group-api';
+import { useGroupStore } from '@/_store/group-store';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useOptimisticUpdate } from './useOptimisticUpdate';
+
+export const useGroup = (options = {}, id: number) => {
+  const { setGroup, clearGroup } = useGroupStore();
+  const queryClient = useQueryClient();
+
+  // 그룹 정보 조회
+  const useGetGroupInfo = useQuery({
+    queryKey: ['group', id],
+    queryFn: () => getGroupInfo(id),
+    ...options,
+  });
+
+  // 그룹 정보 수정
+  const useUpdateGroupInfo = useOptimisticUpdate({
+    mutationFn: (data: { image: string; name: string }) =>
+      updateGroupInfo(id, data),
+    queryKey: ['group', id],
+    updater: (oldData, newData) => ({
+      ...oldData,
+      ...newData,
+    }),
+  });
+
+  // 그룹 삭제
+  const useDeleteGroupInfo = useMutation({
+    mutationFn: (id: number) => deleteGroupInfo(id),
+    onSuccess: () => {
+      clearGroup();
+      queryClient.invalidateQueries({ queryKey: ['group'] });
+    },
+  });
+
+  // 그룹 생성
+  const useCreateGroup = useMutation({
+    mutationFn: createGroup,
+    onSuccess: (data) => {
+      setGroup(data);
+      queryClient.invalidateQueries({ queryKey: ['group'] });
+    },
+  });
+
+  // 그룹 멤버 조회
+  const useGetGroupMember = useQuery({
+    queryKey: ['group', id, 'members'],
+    queryFn: () => getGroupMember(id, 0),
+    ...options,
+  });
+
+  // 그룹 멤버 삭제
+  const useDeleteGroupMember = useMutation({
+    mutationFn: (memberUserId: number) => deleteGroupMember(id, memberUserId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['group', id, 'members'] });
+    },
+  });
+
+  // 초대 링크 생성
+  const useCreateGroupInvitation = useMutation({
+    mutationFn: () => createGroupInvitation(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['groupInvitation', id] });
+    },
+  });
+
+  // 초대 수락
+  const useAcceptGroupInvitation = useMutation({
+    mutationFn: (data: { userEmail: string; token: string }) =>
+      acceptGroupInvitation(data.userEmail, data.token),
+    onSuccess: (data) => {
+      setGroup(data);
+      queryClient.invalidateQueries({ queryKey: ['group', id] });
+    },
+  });
+
+  // 그룹 멤버 추가
+  const useAddGroupMember = useMutation({
+    mutationFn: (userEmail: string) => addGroupMember(id, userEmail),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['group', id, 'members'] });
+    },
+  });
+
+  // 특정 일자 할 일 리스트
+  const useGetGroupTasks = (id: number, date: string) =>
+    useQuery({
+      queryKey: ['group', id, 'tasks', date],
+      queryFn: () => getGroupTasks(id, date),
+      ...options,
+    });
+
+  return {
+    useGetGroupInfo,
+    useUpdateGroupInfo,
+    useDeleteGroupInfo,
+    useCreateGroup,
+    useGetGroupMember,
+    useCreateGroupInvitation,
+    useAcceptGroupInvitation,
+    useDeleteGroupMember,
+    useAddGroupMember,
+    useGetGroupTasks,
+  };
+};

--- a/app/_hooks/useOptimisticUpdate.ts
+++ b/app/_hooks/useOptimisticUpdate.ts
@@ -1,0 +1,37 @@
+import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface UseOptimisticUpdateOptions<TData, TVariables> {
+  mutationFn: (variables: TVariables) => Promise<TData>;
+  queryKey: QueryKey;
+  updater: (oldData: TData | undefined, newData: TVariables) => TData;
+}
+
+export const useOptimisticUpdate = <TData, TVariables>({
+  mutationFn,
+  queryKey,
+  updater,
+}: UseOptimisticUpdateOptions<TData, TVariables>) => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn,
+    onMutate: async (newData) => {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousData = queryClient.getQueryData<TData>(queryKey);
+
+      queryClient.setQueryData<TData>(queryKey, (oldData) =>
+        updater(oldData, newData),
+      );
+
+      return { previousData };
+    },
+    onError: (error, newData, context) => {
+      queryClient.setQueryData(queryKey, context?.previousData);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+  return mutation;
+};

--- a/app/_hooks/useUser.ts
+++ b/app/_hooks/useUser.ts
@@ -11,33 +11,32 @@ import {
 } from '@/_lib/api/user-api';
 import { useUserStore } from '@/_store/user-store';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useOptimisticUpdate } from './useOptimisticUpdate';
 
 export const useUser = (options = {}) => {
-  const { setUser, clearUser } = useUserStore();
+  const { clearUser } = useUserStore();
   const queryClient = useQueryClient();
 
   // 유저 정보 조회
-  const getUserInfoQuery = useQuery({
+  const useGetUserInfo = useQuery({
     queryKey: ['user'],
-    queryFn: async () => {
-      const userInfo = await getUserInfo();
-      setUser(userInfo);
-      return userInfo;
-    },
+    queryFn: getUserInfo,
     ...options,
   });
 
   //유저 정보 수정
-  const updateUserInfoMutation = useMutation({
-    mutationFn: updateUserInfo,
-    onSuccess: (updateUser) => {
-      setUser(updateUser);
-      queryClient.invalidateQueries({ queryKey: ['user'] });
-    },
+  const useUpdateUserInfo = useOptimisticUpdate({
+    mutationFn: (data: { nickname: string; image: string }) =>
+      updateUserInfo(data),
+    queryKey: ['user'],
+    updater: (oldData, newData) => ({
+      ...oldData,
+      ...newData,
+    }),
   });
 
   // 회원 탈퇴
-  const deleteUserMutation = useMutation({
+  const useDeleteUser = useMutation({
     mutationFn: deleteUser,
     onSuccess: () => {
       clearUser();
@@ -46,28 +45,28 @@ export const useUser = (options = {}) => {
   });
 
   // 유저가 속한 그룹 목록 조회
-  const getUserGroupsQuery = useQuery({
+  const useGetUserGroups = useQuery({
     queryKey: ['userGroups'],
     queryFn: getUserGroups,
     ...options,
   });
 
   // 유저의 멤버십 정보 조회
-  const getUserMembershipsQuery = useQuery({
+  const useGetUserMemberships = useQuery({
     queryKey: ['userMemberships'],
     queryFn: getUserMemberships,
     ...options,
   });
 
   // 유저가 완료한 작업 조회
-  const getUserHistoryQuery = useQuery({
+  const useGetUserHistory = useQuery({
     queryKey: ['userHistory'],
     queryFn: getUserHistory,
     ...options,
   });
 
   // 비밀번호 재설정 이메일 전송
-  const sendResetPasswordEmailMutation = useMutation({
+  const useSendResetPasswordEmail = useMutation({
     mutationFn: ({
       email,
       redirectUrl,
@@ -81,7 +80,7 @@ export const useUser = (options = {}) => {
   });
 
   // 비밀번호 재설정
-  const resetPasswordMutation = useMutation({
+  const useResetPassword = useMutation({
     mutationFn: ({
       token,
       password,
@@ -97,7 +96,7 @@ export const useUser = (options = {}) => {
   });
 
   // 비밀번호 변경
-  const passwordMutation = useMutation({
+  const usePassword = useMutation({
     mutationFn: ({
       password,
       passwordConfirmation,
@@ -111,14 +110,14 @@ export const useUser = (options = {}) => {
   });
 
   return {
-    getUserInfoQuery,
-    updateUserInfoMutation,
-    deleteUserMutation,
-    getUserGroupsQuery,
-    getUserMembershipsQuery,
-    getUserHistoryQuery,
-    sendResetPasswordEmailMutation,
-    resetPasswordMutation,
-    passwordMutation,
+    useGetUserInfo,
+    useUpdateUserInfo,
+    useDeleteUser,
+    useGetUserGroups,
+    useGetUserMemberships,
+    useGetUserHistory,
+    useSendResetPasswordEmail,
+    useResetPassword,
+    usePassword,
   };
 };

--- a/app/_lib/api/group-api.ts
+++ b/app/_lib/api/group-api.ts
@@ -1,0 +1,74 @@
+import { instance } from '../axios-instance';
+
+// 그룹 정보 조회
+export const getGroupInfo = async (id: number) => {
+  const response = await instance.get(`/groups/${id}`);
+  return response.data;
+};
+
+// 그룹 정보 수정
+export const updateGroupInfo = async (
+  id: number,
+  data: { image: string; name: string },
+) => {
+  const response = await instance.patch(`/groups/${id}`, data);
+  return response.data;
+};
+
+// 그룹 삭제
+export const deleteGroupInfo = async (id: number) => {
+  const response = await instance.delete(`/groups/${id}`);
+  return response.status;
+};
+
+// 그룹 생성
+export const createGroup = async (data: { image: string; name: string }) => {
+  const response = await instance.post(`/groups`, data);
+  return response.data;
+};
+
+// 그룹 멤버 조회
+export const getGroupMember = async (id: number, memberUserId: number) => {
+  const response = await instance.get(`/groups/${id}/member/${memberUserId}`);
+  return response.data;
+};
+
+// 그룹 멤버 삭제
+export const deleteGroupMember = async (id: number, memberUserId: number) => {
+  const response = await instance.delete(
+    `/groups/${id}/member/${memberUserId}`,
+  );
+  return response.status;
+};
+
+// 초대 링크 생성
+export const createGroupInvitation = async (id: number) => {
+  const response = await instance.get(`/groups/${id}/invitation`);
+  return response.data;
+};
+
+// 초대 수락
+export const acceptGroupInvitation = async (
+  userEmail: string,
+  token: string,
+) => {
+  const response = await instance.post(`/groups/accept-invitation`, {
+    token,
+    userEmail,
+  });
+  return response.data;
+};
+
+// 그룹 멤버 추가
+export const addGroupMember = async (id: number, userEmail: string) => {
+  const response = await instance.post(`/groups/${id}/member`, { userEmail });
+  return response.status;
+};
+
+// 특정 일자 할 일 리스트
+export const getGroupTasks = async (id: number, date: string) => {
+  const response = await instance.get(`/groups/${id}/tasks`, {
+    params: { date },
+  });
+  return response.data;
+};

--- a/app/_store/group-store.ts
+++ b/app/_store/group-store.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+import { taskLists } from './task-list-store';
+
+export interface Group {
+  updatedAt: string;
+  createdAt: string;
+  image: string | null;
+  name: string;
+  id: number;
+  members: Member[];
+  taskLists: taskLists;
+}
+
+interface Member {
+  role: 'ADMIN' | 'MEMBER';
+  userImage: string | null;
+  userEmail: string;
+  userName: string;
+  groupId: number;
+  userId: number;
+}
+
+interface GroupState {
+  group: Group | null;
+  members: Member[];
+}
+
+interface GroupActions {
+  setGroup: (group: Group) => void;
+  clearGroup: () => void;
+  setGroupMembers: (members: Member[]) => void;
+}
+
+export const useGroupStore = create<GroupState & GroupActions>((set) => ({
+  group: null,
+  members: [],
+  setGroup: (group) => set({ group }),
+  clearGroup: () => set({ group: null }),
+  setGroupMembers: (members: Member[]) => set({ members: members }),
+}));

--- a/app/_store/task-list-store.ts
+++ b/app/_store/task-list-store.ts
@@ -1,0 +1,9 @@
+export interface taskLists {
+  displayIndex: number;
+  groupId: number;
+  updatedAt: string;
+  createdAt: string;
+  name: string;
+  id: number;
+  tasks: string[];
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
1. 기존에 `~mutation`, `~query`로 작성되었던 변수명들을 `use~` 형식으로 변경
2. 그룹 API 작성했지만, 데이터가 정상적으로 받아지는지는 확인하지 못함(추후 api 연결 시 확인 필요)
3. 낙관적 업데이트를 위한 훅(`useOptimisticUpdate`)을 작성하고 적용함
## 📎 Issue 번호
#39 
<!-- closed #번호 -->
