### PR TITLE
로그인/회원가입 UI 미완성본

### DIFF
--- a/app/(routes)/Login/page.tsx
+++ b/app/(routes)/Login/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import React from "react";
+import LoginForm from "@/_components/Login/LoginForm";
+import SimpleLogin from "@/_components/Login/SimpleLogin";
+import AuthLayout from "@/_components/layout/Header/AuthLayout";
+
+const Page: React.FC = () => {
+  return (
+    <AuthLayout>
+      <div className="space-y-8">
+        <LoginForm />
+        <SimpleLogin />
+      </div>
+    </AuthLayout>
+  );
+};
+
+export default Page;

--- a/app/(routes)/signup/Page.tsx
+++ b/app/(routes)/signup/Page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import React from 'react';
+import SignupForm from '@/_components/Signup/SignupForm';
+import SimpleLogin from '@/_components/Login/SimpleLogin';
+
+const Page: React.FC = () => (
+  <div className="flex flex-col items-center justify-center min-h-screen ">
+    <SignupForm />
+    <SimpleLogin />
+  </div>
+);
+
+export default Page;
+

--- a/app/_components/Login/AuthHeader.tsx
+++ b/app/_components/Login/AuthHeader.tsx
@@ -1,0 +1,23 @@
+// components/AuthHeader.tsx
+import Link from 'next/link';
+import Image from 'next/image';
+
+const AuthHeader: React.FC = () => {
+  return (
+    <header className="sticky top-0 z-10 w-full h-[6rem] bg-background-secondary flex items-center justify-start px-[1.6rem] tablet:px-[3.2rem] pc:px-[16vw]">
+      <Link href="/" aria-label="홈으로 이동">
+        <Image
+          src="/icons/logo.svg"
+          alt="Coworkers 로고"
+          width={158}
+          height={32}
+          sizes="15.8rem"
+          priority
+          className="cursor-pointer"
+        />
+      </Link>
+    </header>
+  );
+};
+
+export default AuthHeader;

--- a/app/_components/Login/LoginForm.tsx
+++ b/app/_components/Login/LoginForm.tsx
@@ -1,0 +1,73 @@
+// components/LoginForm.tsx
+import React from "react";
+import EmailInput from "@/_components/common/Input/EmailInput";
+import PasswordInput from "@/_components/common/Input/PasswordInput";
+import Button from "@/_components/common/Button";
+
+const LoginForm: React.FC = () => {
+  return (
+    <div className="flex flex-col justify-center items-center mx-auto pc:mt-[10rem] pc:w-[28rem] tablet:mt-[8rem] tablet:w-[22rem] mobile:mt-[4rem] mobile:w-[18rem]">
+      <div className="w-full">
+        {/* 제목 */}
+        <h1 className="text-text-primary text-center mb-[3rem] pc:text-[2rem] pc:leading-[2.5rem] tablet:text-[1.5rem] tablet:leading-[2rem] mobile:text-[1.25rem] mobile:leading-[1.75rem] font-medium">
+          로그인
+        </h1>
+
+        {/* 폼 영역 */}
+        <form>
+          <div className="flex flex-col pc:gap-[1.5rem] tablet:gap-[1.25rem] mobile:gap-[1rem]">
+            {/* 이메일 입력 */}
+            <EmailInput
+              label="이메일"
+              value=""
+              onChange={() => {}}
+              placeholder="이메일을 입력해주세요."
+            />
+
+            {/* 비밀번호 입력 */}
+            <PasswordInput
+              value=""
+              onChange={() => {}}
+              placeholder="비밀번호를 입력해주세요."
+            />
+
+            {/* 비밀번호 찾기 링크 */}
+            <div className="mb-[1.5rem] text-right">
+              <a
+                href="#"
+                className="text-brand-primary pc:text-[0.9rem] tablet:text-[0.8rem] mobile:text-[0.7rem] font-medium underline underline-offset-2 hover:opacity-80"
+              >
+                비밀번호를 잊으셨나요?
+              </a>
+            </div>
+          </div>
+
+          {/* 로그인 버튼 */}
+          <Button
+            size="large"
+            variant="default"
+            className="w-full pc:h-[3rem] tablet:h-[2.75rem] mobile:h-[2.5rem] bg-brand-primary text-white pc:text-[1rem] tablet:text-[0.9rem] mobile:text-[0.8rem] font-semibold rounded-[0.5rem] hover:opacity-90"
+            onClick={() => {}}
+          >
+            로그인
+          </Button>
+        </form>
+
+        {/* 가입하기 링크 */}
+        <div className="text-center mt-6 text-text-primary pc:text-[0.9rem] tablet:text-[0.8rem] mobile:text-[0.7rem] font-medium">
+          아직 계정이 없으신가요?{" "}
+          <a
+            href="/signup"
+            className="text-brand-primary font-medium underline underline-offset-2 hover:opacity-80 ml-5"
+          >
+            가입하기
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginForm;
+
+

--- a/app/_components/Login/SimpleLogin.tsx
+++ b/app/_components/Login/SimpleLogin.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Image from 'next/image';
+
+const SimpleLogin = () => {
+  return (
+    <div className="flex flex-col items-center w-full max-w-[40rem] mx-auto py-4">
+      <div className="relative flex items-center w-full mb-4">
+        <div className="flex-grow border-t border-border-primary"></div>
+        <span className="mx-4 text-text-inverse text-[1.4rem]">OR</span>
+        <div className="flex-grow border-t border-border-primary"></div>
+      </div>
+      <div className="flex items-center gap-20 mb-4">
+        <p className=" text-left text-text-inverse text-[1rem] font-medium">간편 로그인하기</p>
+        <div className="flex justify-center items-center gap-6">
+          <button
+            className="flex items-center justify-center w-[2.65rem] h-[2.65rem] bg-white border border-gray-300 rounded-full shadow-sm hover:shadow-md focus:outline-none"
+            aria-label="Login with Google"
+          >
+            <Image src="/images/google.png" alt="Google" width={32} height={32} />
+          </button>
+          <button
+            className="flex items-center justify-center w-[2.65rem] h-[2.65rem] border border-gray-300 rounded-full shadow-sm hover:shadow-md focus:outline-none"
+            aria-label="Login with Kakao"
+          >
+            <Image src="/images/kakaotalk.png" alt="Kakao" width={32} height={32} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SimpleLogin;
+
+

--- a/app/_components/Signup/SignupForm.tsx
+++ b/app/_components/Signup/SignupForm.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import EmailInput from '@/_components/common/Input/EmailInput';
+import PasswordInput from '@/_components/common/Input/PasswordInput';
+import Input from '@/_components/common/Input/Input';
+import Button from '@/_components/common/Button';
+
+const SignupForm: React.FC = () => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log(e.target.value); // 임시 동작
+  };
+
+  return (
+    <div className="flex flex-col justify-center items-center mx-auto max-w-full pc:mt-[10rem] pc:w-[28rem] tablet:mt-[8rem] tablet:w-[22rem] mobile:mt-[4rem] mobile:w-[18rem]">
+      <div className="w-full flex flex-col gap-3">
+        <h2 className="text-text-primary text-center mb-[3rem] pc:text-[3rem] pc:leading-[2.5rem] tablet:text-[1.5rem] tablet:leading-[2rem] mobile:text-[1.25rem] mobile:leading-[1.75rem] font-medium">
+          회원가입
+        </h2>
+
+        <Input
+          label="이름"
+          value=""
+          placeholder="이름을 입력해 주세요."
+          id="name"
+          onChange={handleInputChange}
+          className="text-[1rem]"
+        />
+        <EmailInput
+          label="이메일"
+          value=""
+          placeholder="이메일을 입력해 주세요."
+          id="email"
+          onChange={handleInputChange}
+          className="text-[1rem]"
+        />
+        <PasswordInput
+          value=""
+          placeholder="비밀번호를 입력해 주세요."
+          id="password"
+          onChange={handleInputChange}
+        />
+        <PasswordInput
+          value=""
+          placeholder="비밀번호를 다시 한 번 입력해 주세요."
+          id="confirmPassword"
+          onChange={handleInputChange}
+        />
+
+        <Button
+          className="w-full pc:h-[3rem] mt-3 mb-8 tablet:h-[2.75rem] mobile:h-[2.5rem] bg-brand-primary text-white pc:text-[1rem] tablet:text-[0.9rem] mobile:text-[0.8rem] font-semibold rounded-[0.5rem] hover:opacity-90"
+          size="large"
+          variant="default"
+        >
+          회원가입
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default SignupForm;
+
+

--- a/app/_components/layout/Header/AuthLayout.tsx
+++ b/app/_components/layout/Header/AuthLayout.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import React from "react";
+import AuthHeader from "@/_components//Login/AuthHeader";
+
+const AuthLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <AuthHeader />
+      <main className="flex flex-1 items-center justify-center">{children}</main>
+    </div>
+  );
+};
+
+export default AuthLayout;
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@radix-ui/react-slot": "^1.1.1",
         "@tanstack/react-query": "^5.64.1",
         "axios": "^1.7.9",
-        "classnames": "^2.5.1",
         "class-variance-authority": "^0.7.1",
+        "classnames": "^2.5.1",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "dayjs": "^1.11.13",
@@ -2222,6 +2222,24 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",


### PR DESCRIPTION
## 📄 작업 내용 요약

- [x] AuthHeader.tsx
로그인,회원가입,비밀번호 재설정, 팀 생성, 팀 참여 페이지에서 사용되는 헤더
근데 기본 레이아웃 헤더가 계속 적용이 되서 어떻게 적용시킬지는 아직 계속 찾는 중입니다
여러가지 해봤는데 계속 안되서 일단 적용은 못시켰습니다. 방법 계속 찾고 있는 중입니다 혹시 알고 계시면 알려주시면 감사하겠습니다!!

변경된 인풋 적용 예정이고 그때 같이 디자인 작업할 예정입니다.
- [x] LoginForm.tsx

- [x] SimpleLogin.tsx

- [x] SignupForm.tsx

로그인 페이지 

<img width="781" alt="스크린샷 2025-02-07 오전 4 34 38" src="https://github.com/user-attachments/assets/17261a1f-fcd9-419c-a98e-b44190f75762" />

이런식으로 헤더를 적용을 했더니 계속 겹치는 식으로 헤더가 나옵니다. 

회원가입 페이지

<img width="767" alt="스크린샷 2025-02-07 오전 4 32 47" src="https://github.com/user-attachments/assets/8b46add5-9281-41ec-9fb4-cd73513f1178" />


#75 # 📎 Issue 번호 

<!-- closed #75  -->
